### PR TITLE
fixed error new users in page profile

### DIFF
--- a/app/src/main/java/com/example/mediam/login/view/Register.kt
+++ b/app/src/main/java/com/example/mediam/login/view/Register.kt
@@ -1,7 +1,6 @@
 package com.example.mediam.login.view
 
 import android.content.Intent
-import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Toast
@@ -32,7 +31,7 @@ class Register : AppCompatActivity() {
         binding.btnRegister.setOnClickListener {
             viewModel.singUp().observe(this) {
                 it?.let {
-                    login(it)
+                    goToLogin(it)
                 }?:run {
                     Toast.makeText(applicationContext, "Error", Toast.LENGTH_SHORT).show()
                 }
@@ -44,20 +43,12 @@ class Register : AppCompatActivity() {
         }
     }
 
-    private fun login(user: User) {
-        val preferences: SharedPreferences =
-            getSharedPreferences("shad.pref", MODE_PRIVATE)
-        val editor: SharedPreferences.Editor = preferences.edit()
-        editor.putBoolean("login", true)
-        editor.apply()
-
-        val intentLogin = Intent(applicationContext, MainNavigationActivity::class.java)
+    private fun goToLogin(user: User) {
+        val intentLogin = Intent(applicationContext, MainActivity::class.java)
         intentLogin.apply {
-            //putExtra("message", "Hola")
-            putExtra("data", user.email)
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         startActivity(intentLogin)
-        Toast.makeText(this, "Inciando Sesion....", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, "Registro exitoso", Toast.LENGTH_SHORT).show()
     }
 }


### PR DESCRIPTION
Solucionado un error.

Cuando se registraba un usuario, este accedia inmediatamente al home de la aplicación, es decir, hacia "login".
cuando se navegaba hacia la pantalla de PERFIL saltaba errores porque para rellenar la información se consulta firestore, enviando el id (el cual firestore crea automaticamente). por ende cuando un usuario nuevo se registra, aun no conoce su id y no se puede traer su info.